### PR TITLE
Fix build issue due to parent pom relative path incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 ```bash 
 docker run -it -p 11222:11222 jboss/infinispan-server:9.4.0.Final
 ```
+(Please note that try to run infinispan server version >9.x.x *might not* be compibled with this example. )
+
+# Build first
+Please build and install first before run,  because there are some common module dependency needs to be installed in your local maven repository.
+
+```bash
+mvn clean install
+```
+
 
 # Load Data
 This project is a simple spring-boot app that connects to a Remote Cache and loads a list of data.
@@ -10,7 +19,7 @@ The data is stored in a cache called `contributors` of type `Integer`/`Contribut
 A 'Contributor' has an int 'code' and a 'String' name.
 
 ```bash
-cd server
+cd writer
 mvn spring-boot:run
 ```
 
@@ -43,7 +52,6 @@ mvn spring-boot:run
 cd reader-near-spring
 mvn spring-boot:run
 ```
-
 
 # Infinispan Spring-Boot starter
 This project is built using the [Infinispan Spring-Boot Starter](https://github.com/infinispan/infinispan-spring-boot)

--- a/reader/common/pom.xml
+++ b/reader/common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-near-cache-parent</artifactId>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
         <version>1.0-SNAPSHOT</version>
     </parent>
 

--- a/reader/reader-near-code/pom.xml
+++ b/reader/reader-near-code/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-near-cache-parent</artifactId>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
         <version>1.0-SNAPSHOT</version>
     </parent>
 

--- a/reader/reader-near-hotrod/pom.xml
+++ b/reader/reader-near-hotrod/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-near-cache-parent</artifactId>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
         <version>1.0-SNAPSHOT</version>
     </parent>
 

--- a/reader/reader-near-spring/pom.xml
+++ b/reader/reader-near-spring/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-near-cache-parent</artifactId>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
         <version>1.0-SNAPSHOT</version>
     </parent>
 

--- a/reader/reader-no-near-cache/pom.xml
+++ b/reader/reader-no-near-cache/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-near-cache-parent</artifactId>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../pom.xml</relativePath>
         <version>1.0-SNAPSHOT</version>
     </parent>
 


### PR DESCRIPTION
As subject, it won't be able to build for a clean machine due to incorrect parent pom reference.
To reproduce this, just use a clean local maven repository, or remove the following:
rm -rf ~/.m2/repository/org/infinispan/infinispan-near-cache-parent/
rm -rf ~/.m2/repository/org/infinispan/infinispan-data-*

I also modified the README.md a bit since I found higher version of infinispan not working with springboot integration anymore due to security part changed.